### PR TITLE
Remove "Click here to" in two places

### DIFF
--- a/assets/mu-plugin/health-check-disable-plugins.php
+++ b/assets/mu-plugin/health-check-disable-plugins.php
@@ -287,7 +287,7 @@ class Health_Check_Troubleshooting_MU {
 				if ( in_array( $plugin_slug, $allowed_plugins ) ) {
 					$label = sprintf(
 					// Translators: %s: Plugin slug.
-						esc_html__( 'Click to disable %s', 'health-check' ),
+						esc_html__( 'Disable %s', 'health-check' ),
 						sprintf(
 							'<strong>%s</strong>',
 							$plugin_slug
@@ -298,7 +298,7 @@ class Health_Check_Troubleshooting_MU {
 					$enabled = false;
 					$label   = sprintf(
 					// Translators: %s: Plugin slug.
-						esc_html__( 'Click to enable %s', 'health-check' ),
+						esc_html__( 'Enable %s', 'health-check' ),
 						sprintf(
 							'<strong>%s</strong>',
 							$plugin_slug


### PR DESCRIPTION
The troubleshooting menu currently builds a long list of menu entries like: "Click here to disable...". It's enough to simply say "Disable..."